### PR TITLE
Adds support for generating services from controllers with typed parameters

### DIFF
--- a/CSharp2TS.CLI/Generators/Entities/TSProperty.cs
+++ b/CSharp2TS.CLI/Generators/Entities/TSProperty.cs
@@ -23,6 +23,7 @@ namespace CSharp2TS.CLI.Generators.Entities {
                 TSType.FormData => "FormData",
                 TSType.Void => "void",
                 TSType.Object => ObjectName ?? "Object",
+                TSType.Unknown => "unknown",
                 _ => throw new NotSupportedException($"Type '{TSType}' is not supported.")
             };
         }

--- a/CSharp2TS.CLI/Generators/Entities/TSType.cs
+++ b/CSharp2TS.CLI/Generators/Entities/TSType.cs
@@ -7,5 +7,6 @@
         FormData,
         Void,
         Object,
+        Unknown,
     }
 }

--- a/CSharp2TS.CLI/Generators/GeneratorBase.cs
+++ b/CSharp2TS.CLI/Generators/GeneratorBase.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using Mono.Cecil;
+using System.Text.Json;
 
 namespace CSharp2TS.CLI.Generators {
     public abstract class GeneratorBase<TAttribute> where TAttribute : TSAttributeBase {
@@ -15,6 +16,7 @@ namespace CSharp2TS.CLI.Generators {
         private static readonly Type[] fileReturnTypes = [typeof(FileContentResult), typeof(FileStreamResult), typeof(FileResult)];
         private static readonly Type[] fileTypes = [typeof(FormFile), typeof(IFormFile), .. fileCollectionTypes, .. fileReturnTypes];
         private static readonly Type[] formDataTypes = [typeof(IFormCollection)];
+        private static readonly Type[] unknownTypes = [typeof(JsonElement)];
         private static readonly Type[] numberTypes = [
             typeof(sbyte), typeof(byte), typeof(short),
             typeof(ushort), typeof(int), typeof(uint),
@@ -85,6 +87,8 @@ namespace CSharp2TS.CLI.Generators {
             } else if (formDataTypes.Any(i => SimpleTypeCheck(type, i))) {
                 isObject = true;
                 tsType = TSType.FormData;
+            } else if (unknownTypes.Any(i => SimpleTypeCheck(type, i))) {
+                tsType = TSType.Unknown;
             } else {
                 isObject = true;
                 requiresImport = true;

--- a/CSharp2TS.CLI/Generators/TSAxiosServiceGenerator.cs
+++ b/CSharp2TS.CLI/Generators/TSAxiosServiceGenerator.cs
@@ -162,7 +162,8 @@ namespace CSharp2TS.CLI.Generators {
             }
 
             if (!string.IsNullOrWhiteSpace(httpMethodAttribute.Template)) {
-                controllerRoute += "/" + httpMethodAttribute.Template.Replace("{", "${");
+                var template = GeneratorUtility.GetCleanRouteConstraints(httpMethodAttribute.Template);
+                controllerRoute += "/" + template;
             }
 
             return controllerRoute;

--- a/CSharp2TS.CLI/Utility/GeneratorUtility.cs
+++ b/CSharp2TS.CLI/Utility/GeneratorUtility.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CSharp2TS.CLI.Utility {
+    public static class GeneratorUtility {
+        public static string GetCleanRouteConstraints(string template) {
+            if (string.IsNullOrWhiteSpace(template))
+                return template;
+
+            // Matches "{paramName:someConstraint}", capturing "paramName" in a group called "param"
+            const string ConstraintPattern = @"\{(?<param>\w+)(?:\:[^}]+)?\}";
+
+            return Regex.Replace(
+                template,
+                ConstraintPattern,
+                match => "${" + match.Groups["param"].Value + "}"
+            );
+        }
+    }
+}

--- a/CSharp2TS.Tests/CSharp2TS.Tests.csproj
+++ b/CSharp2TS.Tests/CSharp2TS.Tests.csproj
@@ -29,6 +29,9 @@
     <None Update="config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Expected\TestJsonElement.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Expected\FormService.ts">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/CSharp2TS.Tests/Expected/TestJsonElement.ts
+++ b/CSharp2TS.Tests/Expected/TestJsonElement.ts
@@ -1,0 +1,7 @@
+// Auto-generated from TestJsonElement.cs
+
+interface TestJsonElement {
+  json: unknown;
+}
+
+export default TestJsonElement;

--- a/CSharp2TS.Tests/Expected/TestService.ts
+++ b/CSharp2TS.Tests/Expected/TestService.ts
@@ -55,4 +55,8 @@ export default {
     await apiClient.instance.delete(`api/Test/${id}`);
   },
 
+  async getWithTypedParam(id: number): Promise<void> {
+    await apiClient.instance.get(`api/Test/${id}`);
+  },
+
 };

--- a/CSharp2TS.Tests/ModelGenerationTests.cs
+++ b/CSharp2TS.Tests/ModelGenerationTests.cs
@@ -83,5 +83,11 @@ namespace CSharp2TS.Tests {
             // Assert
             Assert.That(generated, Is.EqualTo(expected));
         }
+
+        [Test]
+        [TestCase("TestJsonElement.ts", "Expected\\TestJsonElement.ts")]
+        public void Generation_TestJsonElement(string generatedFile, string expectedFile) {
+            TestFilesMatch(generatedFile, expectedFile);
+        }
     }
 }

--- a/CSharp2TS.Tests/Stubs/Controllers/ActionResult_TestController.cs
+++ b/CSharp2TS.Tests/Stubs/Controllers/ActionResult_TestController.cs
@@ -59,5 +59,10 @@ namespace CSharp2TS.Tests.Stubs.Controllers {
         public ActionResult Delete(int id) {
             throw new NotImplementedException();
         }
+
+        [HttpGet("{id:int}")]
+        public ActionResult GetWithTypedParam(int id) {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/CSharp2TS.Tests/Stubs/Controllers/AsyncActionResult_TestController.cs
+++ b/CSharp2TS.Tests/Stubs/Controllers/AsyncActionResult_TestController.cs
@@ -69,5 +69,11 @@ namespace CSharp2TS.Tests.Stubs.Controllers {
             await Task.CompletedTask;
             throw new NotImplementedException();
         }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult> GetWithTypedParam(int id) {
+            await Task.CompletedTask;
+            throw new NotImplementedException();
+        }
     }
 }

--- a/CSharp2TS.Tests/Stubs/Controllers/AsyncIActionResult_TestController.cs
+++ b/CSharp2TS.Tests/Stubs/Controllers/AsyncIActionResult_TestController.cs
@@ -76,5 +76,11 @@ namespace CSharp2TS.Tests.Stubs.Controllers {
             await Task.CompletedTask;
             throw new NotImplementedException();
         }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetWithTypedParam(int id) {
+            await Task.CompletedTask;
+            throw new NotImplementedException();
+        }
     }
 }

--- a/CSharp2TS.Tests/Stubs/Controllers/IActionResult_TestController.cs
+++ b/CSharp2TS.Tests/Stubs/Controllers/IActionResult_TestController.cs
@@ -67,5 +67,10 @@ namespace CSharp2TS.Tests.Stubs.Controllers {
         public IActionResult Delete(int id) {
             throw new NotImplementedException();
         }
+
+        [HttpGet("{id}")]
+        public IActionResult GetWithTypedParam(int id) {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/CSharp2TS.Tests/Stubs/Models/TestJsonElement.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestJsonElement.cs
@@ -1,0 +1,9 @@
+﻿using CSharp2TS.Core.Attributes;
+using System.Text.Json;
+
+namespace CSharp2TS.Tests.Stubs.Models {
+    [TSInterface]
+    public class TestJsonElement {
+        public JsonElement json { get; set; }
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces support for generating TypeScript services from C# controllers that use typed route parameters. Route templates with parameter constraints are now correctly processed and output in the generated TypeScript service code.

### Implementation Details

- __CSharp2TS.CLI/Generators/TSAxiosServiceGenerator.cs__\
  Updated to use a new utility method (`GeneratorUtility.GetCleanRouteConstraints`) for processing controller route templates, improving the handling of typed parameters in routes.

- __CSharp2TS.CLI/Utility/GeneratorUtility.cs__\
  Added a new static utility class with a method to clean and process route constraints from templates, ensuring compatibility with TypeScript template string syntax.

- __CSharp2TS.Tests/Expected/TestService.ts__\
  Updated the expected output to reflect the improved route template handling, demonstrating the correct generation of services with typed parameters.

- __CSharp2TS.Tests/Stubs/Controllers/ActionResult_TestController.cs__

  - __AsyncActionResult_TestController.cs__
  - __AsyncIActionResult_TestController.cs__
  - __IActionResult_TestController.cs__\
    Added or updated controller stubs to include actions with typed route parameters, providing test coverage for the new functionality.

### Motivation and Impact

Previously, route templates with parameter constraints were not handled correctly, which would lead to incorrect TypeScript service generation. This update ensures that all route templates, including those with typed parameters, are processed accurately, improving the reliability and correctness of generated client code.

### Testing

- Updated and added test stubs and expected outputs to validate the new behaviour.
- All existing and new tests pass, confirming the correctness of the implementation.
