### PR TITLE
Include optional onUploadProgress function to generated axios file upload endpoints

### DIFF
--- a/CSharp2TS.CLI/Templates/TSAxiosServiceTemplate.tt
+++ b/CSharp2TS.CLI/Templates/TSAxiosServiceTemplate.tt
@@ -7,13 +7,16 @@
 // Auto-generated from <#= TypeName #>.cs
 
 import { apiClient } from '<#= ApiClientImportPath #>apiClient';
+<# if (Items.Any(item => item.IsBodyRawFile)) { #>
+import type { AxiosProgressEvent } from 'axios';
+<#}#>
 <# foreach (var item in Imports) { #>
 import <#= item.Name #> from '<#= item.Path #>';
-<# } #>
+<#}#>
 
 export default {
 <# foreach (var item in Items) { #>
-  async <#= item.MethodName #>(<#= string.Join(", ", item.AllParams.Select(i => $"{i.Name}: {i.Property}")) #>): Promise<<#= item.ReturnType #>> {
+  async <#= item.MethodName #>(<#= string.Join(", ", item.AllParams.Select(i => $"{i.Name}: {i.Property}")) #><# if (item.IsBodyRawFile) {#>, onUploadProgress?: (event: AxiosProgressEvent) => void<#}#>): Promise<<#= item.ReturnType #>> {
 <# if (item.IsBodyRawFile) {#>
     const formData = new FormData();
 <# if (!item.BodyParam.Property.IsCollection) {#>
@@ -37,6 +40,9 @@ export default {
 <# } #>
 <# if (item.IsBodyFormData) { #>
       headers: { 'Content-Type': 'multipart/form-data' },
+<# } #>
+<# if (item.IsBodyRawFile) { #>
+      onUploadProgress,
 <# } #>
     });
 <# } else { #>

--- a/CSharp2TS.Tests/Expected/FileService.ts
+++ b/CSharp2TS.Tests/Expected/FileService.ts
@@ -1,6 +1,7 @@
 // Auto-generated from FileController.cs
 
 import { apiClient } from './apiClient';
+import type { AxiosProgressEvent } from 'axios';
 
 export default {
   async getFile(): Promise<File> {
@@ -10,16 +11,17 @@ export default {
     return response.data;
   },
 
-  async postFile(file: File): Promise<void> {
+  async postFile(file: File, onUploadProgress?: (event: AxiosProgressEvent) => void): Promise<void> {
     const formData = new FormData();
     formData.append('file', file);
 
     await apiClient.instance.post(`api/file`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
+      onUploadProgress,
     });
   },
 
-  async postFiles(files: File[]): Promise<void> {
+  async postFiles(files: File[], onUploadProgress?: (event: AxiosProgressEvent) => void): Promise<void> {
     const formData = new FormData();
     for (let i = 0; i < files.length; i++) {
       const f = files[i];
@@ -28,16 +30,18 @@ export default {
 
     await apiClient.instance.post(`api/file`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
+      onUploadProgress,
     });
   },
 
-  async postAndReceiveFile(file: File): Promise<File> {
+  async postAndReceiveFile(file: File, onUploadProgress?: (event: AxiosProgressEvent) => void): Promise<File> {
     const formData = new FormData();
     formData.append('file', file);
 
     const response = await apiClient.instance.post<File>(`api/file`, formData, {
       responseType: 'blob',
       headers: { 'Content-Type': 'multipart/form-data' },
+      onUploadProgress,
     });
     return response.data;
   },


### PR DESCRIPTION
Adds support for passing through the onUploadProgress method when generating axios services which have file uploads. This allows us to hook into the axios wrapper of the native progress event to get file upload progress etc.

https://axios-http.com/docs/req_config
https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/ProgressEvent