### PR TITLE
Handle public methods in tsinterface

### DIFF
--- a/CSharp2TS.CLI/CSharp2TS.CLI.csproj
+++ b/CSharp2TS.CLI/CSharp2TS.CLI.csproj
@@ -13,11 +13,11 @@
     <RepositoryUrl>https://github.com/ormesam/CSharp2TS</RepositoryUrl>
     <Title>$(AssemblyName)</Title>
     <Authors>Sam Orme</Authors>
-    <PackageVersion>0.0.36-alpha</PackageVersion>
+    <PackageVersion>0.0.37-alpha</PackageVersion>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
     <Copyright>Sam Orme</Copyright>
     <PackageTags>csharp2ts;typescript-generator</PackageTags>
-    <PackageReleaseNotes>Handle TSImportAttribute for custom TS imports in services</PackageReleaseNotes>
+    <PackageReleaseNotes>Handle generation of public methods from classes to TS interface</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Description>CSharp2TS.CLI is a tool to generate TypeScript files for C# classes, enums and API endpoints. Requires the CSharp2TS.Core nuget package to be installed on the target project.</Description>
   </PropertyGroup>

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterface.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterface.cs
@@ -5,8 +5,10 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
         public string Name { get; private set; }
         public IList<TSImport> Imports { get; private set; } = [];
         public IList<TSInterfaceProperty> Properties { get; private set; } = [];
+        public IList<TSInterfaceMethod> Methods { get; private set; } = [];
         public IList<string> GenericParameters { get; set; } = [];
         public bool GenerateClass { get; set; }
+        public bool IncludeMethods { get; set; }
 
         public TSInterface(string name) {
             Name = name;

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceGenerator.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using CSharp2TS.CLI.Generators.Common;
 using CSharp2TS.CLI.Generators.Entities;
-using CSharp2TS.CLI.Templates;
 using CSharp2TS.CLI.Utility;
 using CSharp2TS.Core.Attributes;
 using Mono.Cecil;
@@ -17,7 +16,9 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
 
         public string Generate(TypeDefinition typeDef) {
             TSInterface tsInterface = new(NameUtility.GetName(typeDef));
-            tsInterface.GenerateClass = typeDef.GetAttribute<TSInterfaceAttribute>().GetAttributeValue<bool>(nameof(TSInterfaceAttribute.GenerateClass));
+            var interfaceAttribute = typeDef.GetAttribute<TSInterfaceAttribute>();
+            tsInterface.GenerateClass = interfaceAttribute.GetAttributeValue<bool>(nameof(TSInterfaceAttribute.GenerateClass));
+            tsInterface.IncludeMethods = interfaceAttribute.GetAttributeValue<bool>(nameof(TSInterfaceAttribute.IncludeMethods));
 
             ParseTypes(tsInterface, typeDef, typeDef);
 
@@ -30,7 +31,7 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
             }
 
             foreach (var property in typeDef.Properties) {
-                if (property.IsSpecialName || property.HasAttribute<TSExcludeAttribute>() || IsRecordEqualityContract(property)) {
+                if (property.IsSpecialName || !IsPublic(property) || property.HasAttribute<TSExcludeAttribute>() || IsRecordEqualityContract(property)) {
                     continue;
                 }
 
@@ -67,6 +68,53 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
                 tsInterface.Properties.Add(tsProperty);
             }
 
+            if (tsInterface.IncludeMethods) {
+                foreach (var method in typeDef.Methods) {
+                    if (method.IsSpecialName || method.IsConstructor || method.IsStatic || !method.IsPublic || method.HasAttribute<TSExcludeAttribute>()) {
+                        continue;
+                    }
+
+                    string signatureKey = GetMethodSignatureKey(method);
+
+                    if (tsInterface.Methods.Any(i => i.SignatureKey == signatureKey)) {
+                        continue;
+                    }
+
+                    var returnType = TSTypeMapper.GetTSPropertyType(method.ReturnType, options, (fullName, typeName) => {
+                        if (typeDef.FullName != fullName) {
+                            TryAddTSImport(tsInterface, rootTypeDef, fullName, typeName);
+                        }
+
+                        return true;
+                    });
+
+                    List<TSInterfaceMethodParameter> parameters = [];
+
+                    foreach (var parameter in method.Parameters) {
+                        var tsType = TSTypeMapper.GetTSPropertyType(parameter.ParameterType, options, (fullName, typeName) => {
+                            if (typeDef.FullName != fullName) {
+                                TryAddTSImport(tsInterface, rootTypeDef, fullName, typeName);
+                            }
+
+                            return true;
+                        });
+
+                        parameters.Add(new TSInterfaceMethodParameter(
+                            parameter.Name.ApplyCasing(options.MemberNameCasingStyle),
+                            tsType,
+                            parameter.HasAttribute<TSNullableAttribute>()));
+                    }
+
+                    tsInterface.Methods.Add(new TSInterfaceMethod(
+                        method.Name.ApplyCasing(options.MemberNameCasingStyle),
+                        returnType,
+                        parameters,
+                        method.GenericParameters.Select(i => i.Name).ToList(),
+                        signatureKey,
+                        method.HasAttribute<TSNullableAttribute>()));
+                }
+            }
+
             if (typeDef.BaseType != null && typeDef.BaseType.FullName != "System.Object") {
                 ParseTypes(tsInterface, rootTypeDef, typeDef.BaseType.Resolve());
             }
@@ -80,6 +128,14 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
 
         private bool IsRecordEqualityContract(PropertyDefinition property) {
             return property.PropertyType.FullName == typeof(Type).FullName && property.FullName.EndsWith("::EqualityContract()");
+        }
+
+        private bool IsPublic(PropertyDefinition property) {
+            return (property.GetMethod?.IsPublic ?? false) || (property.SetMethod?.IsPublic ?? false);
+        }
+
+        private string GetMethodSignatureKey(MethodDefinition method) {
+            return $"{method.Name}|{method.GenericParameters.Count}|{string.Join("|", method.Parameters.Select(i => i.ParameterType.FullName))}";
         }
 
         private void TryAddTSImport(TSInterface tsInterface, TypeDefinition typeDef, string targetFullName, string targetName) {
@@ -99,10 +155,7 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
         }
 
         private string BuildTsFile(TSInterface tsInterface) {
-            return new TSInterfaceTemplate {
-                TSInterface = tsInterface,
-                GenerateClass = tsInterface.GenerateClass,
-            }.TransformText();
+            return TSInterfaceTypeScriptGenerator.Generate(tsInterface);
         }
     }
 }

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceGenerator.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceGenerator.cs
@@ -18,7 +18,11 @@ namespace CSharp2TS.CLI.Generators.TSInterfaces {
             TSInterface tsInterface = new(NameUtility.GetName(typeDef));
             var interfaceAttribute = typeDef.GetAttribute<TSInterfaceAttribute>();
             tsInterface.GenerateClass = interfaceAttribute.GetAttributeValue<bool>(nameof(TSInterfaceAttribute.GenerateClass));
-            tsInterface.IncludeMethods = interfaceAttribute.GetAttributeValue<bool>(nameof(TSInterfaceAttribute.IncludeMethods));
+            if (interfaceAttribute.TryGetAttributeValue<bool>(nameof(TSInterfaceAttribute.IncludeMethods), out var includeMethods)) {
+                tsInterface.IncludeMethods = includeMethods;
+            } else {
+                tsInterface.IncludeMethods = interfaceAttribute.GetConstructorArgument<bool>();
+            }
 
             ParseTypes(tsInterface, typeDef, typeDef);
 

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceMethod.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceMethod.cs
@@ -1,0 +1,17 @@
+using CSharp2TS.CLI.Generators.Common;
+
+namespace CSharp2TS.CLI.Generators.TSInterfaces {
+    public record TSInterfaceMethod(string Name, TSType ReturnType, IList<TSInterfaceMethodParameter> Parameters, IList<string> GenericParameters, string SignatureKey, bool IsNullableReturnType) {
+        public string GenericString => GenericParameters.Count > 0 ? $"<{string.Join(", ", GenericParameters)}>" : string.Empty;
+
+        public override string ToString() {
+            string returnType = ReturnType.ToString();
+
+            if (IsNullableReturnType && !returnType.EndsWith("| null")) {
+                returnType += " | null";
+            }
+
+            return $"{Name}{GenericString}({string.Join(", ", Parameters)}): {returnType}";
+        }
+    }
+}

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceMethodParameter.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceMethodParameter.cs
@@ -1,0 +1,15 @@
+using CSharp2TS.CLI.Generators.Common;
+
+namespace CSharp2TS.CLI.Generators.TSInterfaces {
+    public record TSInterfaceMethodParameter(string Name, TSType Type, bool IsNullableParameter) {
+        public override string ToString() {
+            string type = Type.ToString();
+
+            if (IsNullableParameter && !type.EndsWith("| null")) {
+                type += " | null";
+            }
+
+            return $"{Name}: {type}";
+        }
+    }
+}

--- a/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceTypeScriptGenerator.cs
+++ b/CSharp2TS.CLI/Generators/TSInterfaces/TSInterfaceTypeScriptGenerator.cs
@@ -1,0 +1,63 @@
+using System.Text;
+
+namespace CSharp2TS.CLI.Generators.TSInterfaces {
+    public static class TSInterfaceTypeScriptGenerator {
+        public static string Generate(TSInterface tsInterface) {
+            StringBuilder sb = new();
+            string genericString = tsInterface.GenericParameters.Count > 0
+                ? $"<{string.Join(", ", tsInterface.GenericParameters)}>"
+                : string.Empty;
+
+            sb.AppendLine($"// Auto-generated from {tsInterface.Name}.cs");
+
+            if (tsInterface.Imports.Count > 0) {
+                sb.AppendLine();
+
+                foreach (var item in tsInterface.Imports) {
+                    sb.AppendLine($"import {item.Name} from '{item.Path}';");
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"interface {tsInterface.Name}{genericString} {{");
+
+            foreach (var item in tsInterface.Properties) {
+                sb.AppendLine($"  {item};");
+            }
+
+            foreach (var method in tsInterface.Methods) {
+                sb.AppendLine($"  {method};");
+            }
+
+            sb.AppendLine("}");
+            sb.AppendLine();
+            sb.AppendLine($"export default {tsInterface.Name};");
+
+            if (tsInterface.GenerateClass) {
+                sb.AppendLine();
+                sb.AppendLine($"export class {tsInterface.Name}Stub{genericString} implements {tsInterface.Name}{genericString} {{");
+
+                foreach (var item in tsInterface.Properties) {
+                    sb.AppendLine($"  {item} = {item.GetDefaultValue()};");
+                }
+
+                foreach (var method in tsInterface.Methods) {
+                    sb.AppendLine();
+                    sb.AppendLine($"  {method} {{");
+                    sb.AppendLine("    throw new Error('Method not implemented.');");
+                    sb.AppendLine("  }");
+                }
+
+                sb.AppendLine();
+                sb.AppendLine($"  constructor(data?: Partial<{tsInterface.Name}>) {{");
+                sb.AppendLine("    if (data) {");
+                sb.AppendLine("      Object.assign(this, data);");
+                sb.AppendLine("    }");
+                sb.AppendLine("  }");
+                sb.AppendLine("}");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/CSharp2TS.CLI/Utility/AttributeExtensions.cs
+++ b/CSharp2TS.CLI/Utility/AttributeExtensions.cs
@@ -55,6 +55,18 @@ namespace CSharp2TS.CLI.Utility {
                 .FirstOrDefault();
         }
 
+        public static bool TryGetAttributeValue<T>(this CustomAttribute attr, string name, out T? value) {
+            var property = attr.Properties.FirstOrDefault(i => i.Name == name);
+
+            if (property.Name == null || property.Argument.Value is not T typedValue) {
+                value = default;
+                return false;
+            }
+
+            value = typedValue;
+            return true;
+        }
+
         public static T? GetConstructorArgument<T>(this CustomAttribute attr, int index = 0) {
             if (!attr.HasConstructorArguments || attr.ConstructorArguments.Count - 1 < index) {
                 return default;

--- a/CSharp2TS.Core/Attributes/TSInterfaceAttribute.cs
+++ b/CSharp2TS.Core/Attributes/TSInterfaceAttribute.cs
@@ -14,10 +14,6 @@
         public TSInterfaceAttribute() : base(null) {
         }
 
-        public TSInterfaceAttribute(bool includeMethods) : base(null) {
-            IncludeMethods = includeMethods;
-        }
-
         public TSInterfaceAttribute(string typeName) : base(typeName) {
         }
     }

--- a/CSharp2TS.Core/Attributes/TSInterfaceAttribute.cs
+++ b/CSharp2TS.Core/Attributes/TSInterfaceAttribute.cs
@@ -6,7 +6,16 @@
         /// </summary>
         public bool GenerateClass { get; set; }
 
+        /// <summary>
+        /// Include public methods in generated TypeScript interfaces/classes.
+        /// </summary>
+        public bool IncludeMethods { get; set; }
+
         public TSInterfaceAttribute() : base(null) {
+        }
+
+        public TSInterfaceAttribute(bool includeMethods) : base(null) {
+            IncludeMethods = includeMethods;
         }
 
         public TSInterfaceAttribute(string typeName) : base(typeName) {

--- a/CSharp2TS.Core/Attributes/TSNullableAttribute.cs
+++ b/CSharp2TS.Core/Attributes/TSNullableAttribute.cs
@@ -1,5 +1,5 @@
 ﻿namespace CSharp2TS.Core.Attributes {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public class TSNullableAttribute : Attribute {
     }
 }

--- a/CSharp2TS.Core/CSharp2TS.Core.csproj
+++ b/CSharp2TS.Core/CSharp2TS.Core.csproj
@@ -11,11 +11,11 @@
     <PackageProjectUrl>https://github.com/ormesam/CSharp2TS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ormesam/CSharp2TS</RepositoryUrl>
     <PackageOutputPath>../nupkg</PackageOutputPath>
-    <PackageVersion>0.0.6-alpha</PackageVersion>
+    <PackageVersion>0.0.7-alpha</PackageVersion>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
     <Copyright>Sam Orme</Copyright>
     <PackageTags>csharp2ts;typescript-generator</PackageTags>
-    <PackageReleaseNotes>Add TSImportAttribute for custom TS imports in services</PackageReleaseNotes>
+    <PackageReleaseNotes>Handle generation of public methods from classes to TS interface</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Description>CSharp2TS.Core is a lightweight package that contains the attributes required for the **CSharp2TS.CLI** dotnet tool to generate TypeScript models and API services.</Description>
   </PropertyGroup>

--- a/CSharp2TS.Core/PACKAGE.md
+++ b/CSharp2TS.Core/PACKAGE.md
@@ -123,6 +123,16 @@ public class TestModel {
 }
 ```
 
+**IncludeMethods** can be passed to `TSInterface` to include public methods in the generated TypeScript type.
+
+```c#
+[TSInterface(IncludeMethods = true)]
+public class TestModel {
+    public bool Test() {}
+    ...
+}
+```
+
 **GenerateClass** can be set on `TSInterface` to also generate a function that returns a default instance of the interface.
 
 ```c#

--- a/CSharp2TS.Core/PACKAGE.md
+++ b/CSharp2TS.Core/PACKAGE.md
@@ -128,7 +128,9 @@ public class TestModel {
 ```c#
 [TSInterface(IncludeMethods = true)]
 public class TestModel {
-    public bool Test() {}
+    public bool Test() {
+        return true;
+    }
     ...
 }
 ```

--- a/CSharp2TS.Tests/CSharp2TS.Tests.csproj
+++ b/CSharp2TS.Tests/CSharp2TS.Tests.csproj
@@ -45,6 +45,15 @@
     <None Update="Expected\TestClassWithStub.ts">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Expected\TestClassWithMethods.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Expected\TestClassWithMethodsDefault.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Expected\TestClassMethodReturnTypes.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Expected\TestEnumDescriptionsAndItemArray.ts">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/CSharp2TS.Tests/Expected/TestClassMethodReturnTypes.ts
+++ b/CSharp2TS.Tests/Expected/TestClassMethodReturnTypes.ts
@@ -1,0 +1,34 @@
+// Auto-generated from TestClassMethodReturnTypes.cs
+
+import TestEnum from './TestEnum';
+import TestClass2 from './TestClass2';
+import GenericClass1 from './GenericClass1';
+
+interface TestClassMethodReturnTypes {
+  id: number;
+  getInt(): number;
+  getNullableInt(): number | null;
+  getDouble(): number;
+  getString(): string;
+  getNullableString(): string | null;
+  getBool(): boolean;
+  getIntArray(): number[];
+  getDoubleArray(): number[];
+  getStringArray(): string[];
+  getBoolArray(): boolean[];
+  getEnum(): TestEnum;
+  getNullableEnum(): TestEnum | null;
+  getClass2(): TestClass2;
+  getGenericClass(): GenericClass1<TestClass2>;
+  getDictionary(): { [key: string]: string };
+  getFile(): File;
+  getFileCollection(): File[];
+  getJson(): unknown;
+  getDateTime(): string;
+  getVoid(): void;
+  getTask(): void;
+  getTaskInt(): number;
+  getEnumerableInt(): number[];
+}
+
+export default TestClassMethodReturnTypes;

--- a/CSharp2TS.Tests/Expected/TestClassWithMethods.ts
+++ b/CSharp2TS.Tests/Expected/TestClassWithMethods.ts
@@ -1,0 +1,29 @@
+// Auto-generated from TestClassWithMethods.cs
+
+import TestClass2 from './TestClass2';
+
+interface TestClassWithMethods {
+  value: number;
+  build(input: TestClass2 | null): TestClass2;
+  reset(): void;
+}
+
+export default TestClassWithMethods;
+
+export class TestClassWithMethodsStub implements TestClassWithMethods {
+  value: number = 0;
+
+  build(input: TestClass2 | null): TestClass2 {
+    throw new Error('Method not implemented.');
+  }
+
+  reset(): void {
+    throw new Error('Method not implemented.');
+  }
+
+  constructor(data?: Partial<TestClassWithMethods>) {
+    if (data) {
+      Object.assign(this, data);
+    }
+  }
+}

--- a/CSharp2TS.Tests/Expected/TestClassWithMethodsDefault.ts
+++ b/CSharp2TS.Tests/Expected/TestClassWithMethodsDefault.ts
@@ -1,0 +1,7 @@
+// Auto-generated from TestClassWithMethodsDefault.cs
+
+interface TestClassWithMethodsDefault {
+  value: number;
+}
+
+export default TestClassWithMethodsDefault;

--- a/CSharp2TS.Tests/Generators/TSInterfaceGeneratorTest.cs
+++ b/CSharp2TS.Tests/Generators/TSInterfaceGeneratorTest.cs
@@ -45,6 +45,9 @@ namespace CSharp2TS.Tests.Generators {
             AddType(typeof(TestEnum));
             AddType(typeof(TestEnumInFolder));
             AddType(typeof(TestClassWithStub));
+            AddType(typeof(TestClassWithMethods));
+            AddType(typeof(TestClassWithMethodsDefault));
+            AddType(typeof(TestClassMethodReturnTypes));
 
             generator = new TSInterfaceGenerator(files, options);
             generatorPascalCase = new TSInterfaceGenerator(files, optionsPascalCase);
@@ -129,6 +132,33 @@ namespace CSharp2TS.Tests.Generators {
             string result = generator.Generate(typeRef.Resolve());
 
             TestMatchesFile("Expected/TestClassWithStub.ts", result);
+        }
+
+        [Test]
+        public void InterfaceGenerator_MethodGeneration() {
+            var typeRef = module.ImportReference(typeof(TestClassWithMethods));
+
+            string result = generator.Generate(typeRef.Resolve());
+
+            TestMatchesFile("Expected/TestClassWithMethods.ts", result);
+        }
+
+        [Test]
+        public void InterfaceGenerator_MethodGeneration_DefaultDisabled() {
+            var typeRef = module.ImportReference(typeof(TestClassWithMethodsDefault));
+
+            string result = generator.Generate(typeRef.Resolve());
+
+            TestMatchesFile("Expected/TestClassWithMethodsDefault.ts", result);
+        }
+
+        [Test]
+        public void InterfaceGenerator_MethodGeneration_ReturnTypes() {
+            var typeRef = module.ImportReference(typeof(TestClassMethodReturnTypes));
+
+            string result = generator.Generate(typeRef.Resolve());
+
+            TestMatchesFile("Expected/TestClassMethodReturnTypes.ts", result);
         }
 
         private void AddType(Type type) {

--- a/CSharp2TS.Tests/Stubs/Models/TestClassMethodReturnTypes.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestClassMethodReturnTypes.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 
 namespace CSharp2TS.Tests.Stubs.Models {
-    [TSInterface(true)]
+    [TSInterface(IncludeMethods = true)]
     public class TestClassMethodReturnTypes {
         public int Id { get; set; }
 

--- a/CSharp2TS.Tests/Stubs/Models/TestClassMethodReturnTypes.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestClassMethodReturnTypes.cs
@@ -1,0 +1,38 @@
+using CSharp2TS.Core.Attributes;
+using CSharp2TS.Tests.Stubs.Enums;
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+
+namespace CSharp2TS.Tests.Stubs.Models {
+    [TSInterface(true)]
+    public class TestClassMethodReturnTypes {
+        public int Id { get; set; }
+
+        public int GetInt() => 0;
+        public int? GetNullableInt() => null;
+        public double GetDouble() => 0;
+        public string GetString() => string.Empty;
+
+        [TSNullable]
+        public string GetNullableString() => string.Empty;
+
+        public bool GetBool() => false;
+        public int[] GetIntArray() => [];
+        public double[] GetDoubleArray() => [];
+        public string[] GetStringArray() => [];
+        public bool[] GetBoolArray() => [];
+        public TestEnum GetEnum() => TestEnum.Value1;
+        public TestEnum? GetNullableEnum() => null;
+        public TestClass2 GetClass2() => new();
+        public GenericClass1<TestClass2> GetGenericClass() => new();
+        public Dictionary<int, string> GetDictionary() => [];
+        public IFormFile GetFile() => null!;
+        public IFormFileCollection GetFileCollection() => null!;
+        public JsonElement GetJson() => new();
+        public DateTime GetDateTime() => DateTime.MinValue;
+        public void GetVoid() { }
+        public Task GetTask() => Task.CompletedTask;
+        public Task<int> GetTaskInt() => Task.FromResult(0);
+        public IEnumerable<int> GetEnumerableInt() => [];
+    }
+}

--- a/CSharp2TS.Tests/Stubs/Models/TestClassWithMethods.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestClassWithMethods.cs
@@ -1,7 +1,7 @@
 using CSharp2TS.Core.Attributes;
 
 namespace CSharp2TS.Tests.Stubs.Models {
-    [TSInterface(true, GenerateClass = true)]
+    [TSInterface(IncludeMethods = true, GenerateClass = true)]
     public class TestClassWithMethods {
         public int Value { get; set; }
         public TestClass2 Build([TSNullable] TestClass2 input) => input;

--- a/CSharp2TS.Tests/Stubs/Models/TestClassWithMethods.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestClassWithMethods.cs
@@ -1,0 +1,16 @@
+using CSharp2TS.Core.Attributes;
+
+namespace CSharp2TS.Tests.Stubs.Models {
+    [TSInterface(true, GenerateClass = true)]
+    public class TestClassWithMethods {
+        public int Value { get; set; }
+        public TestClass2 Build([TSNullable] TestClass2 input) => input;
+        public void Reset() { }
+
+        [TSExclude]
+        public void Hidden() { }
+
+        [TSExclude]
+        public string ExcludedProperty { get; set; } = string.Empty;
+    }
+}

--- a/CSharp2TS.Tests/Stubs/Models/TestClassWithMethodsDefault.cs
+++ b/CSharp2TS.Tests/Stubs/Models/TestClassWithMethodsDefault.cs
@@ -1,0 +1,9 @@
+using CSharp2TS.Core.Attributes;
+
+namespace CSharp2TS.Tests.Stubs.Models {
+    [TSInterface]
+    public class TestClassWithMethodsDefault {
+        public int Value { get; set; }
+        public int Compute() => Value;
+    }
+}


### PR DESCRIPTION
Added a new property `IncludeMethods` in TSInterface attribute to turn on or off the ability to include public methods in the generated TS type.

In the original use-case of this tool ASP.NET controllers with `[TSService]` and `[TSEndpoint]` would be used for this purpose, but I am using it with local Web View and COM interop, where having the methods is super helpful since the C# objects are exposed directly to the web app. (hence why I also added Pascal casing for members earlier 😉 )